### PR TITLE
Customizable criteria and priority

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,34 @@ Or with Docker exec:
 ```sh
 docker exec -it immich-auto-stack /script/immich_auto_stack.sh
 ```
+
+## Customizing the criteria
+
+Configurable criteria allows for the customization of how files are grouped
+The default is equivalent to:
+
+```python
+lambda x: (
+  x["originalFileName"].split(".")[0],
+  x["localDateTime"]
+)
+```
+
+To override the default, pass a new configuration file into docker via
+The CRITERIA env var.
+
+```shell
+docker -e CRITERIA='[{"key": "originalFileName", "split": {"key": "_", "index": 0}}]' ...
+``` 
+
+## Parent priority
+
+Keywords can be provided to prioritize the file that is selected as the parent. For example:
+
+```shell
+docker -e PARENT_PROMOTE="edit,crop,hdr" ...
+``` 
+
 ## License
 
 This project is licensed under the GNU Affero General Public License version 3 (AGPLv3) to align with the licensing of Immich, which this script interacts with. For more details on the rights and obligations under this license, see the [GNU licenses page](https://opensource.org/license/agpl-v3).

--- a/README.md
+++ b/README.md
@@ -60,7 +60,26 @@ docker exec -it immich-auto-stack /script/immich_auto_stack.sh
 ## Customizing the criteria
 
 Configurable criteria allows for the customization of how files are grouped
-The default is equivalent to:
+The default in pretty json is:
+
+```json
+[
+  {
+    "key": "originalFileName",
+    "split": {
+      "key": ".",
+      "index": 0 // this is the default
+    }
+  },
+  {
+    "key": "localDateTime"
+  }
+]
+```
+
+Functionally, this JSON config is the same as the lamdba implementation currently in place:
+
+
 
 ```python
 lambda x: (
@@ -74,15 +93,45 @@ The CRITERIA env var.
 
 ```shell
 docker -e CRITERIA='[{"key": "originalFileName", "split": {"key": "_", "index": 0}}]' ...
-``` 
+```
+
+The parser also supports regex, which adds a lot more flexibility.
+The index will select a substring using `re.match.group(index)`. For example:
+
+```json
+[
+  {
+    "key": "originalFileName",
+    "regex": {
+      "key": "([A-Z]+[-_]?[0-9]{4}([-_][0-9]{4})?)([\\._-].*)?\\.[\\w]{3,4}$",
+      "index": 1 // this is the default
+    }
+  },
+  {
+    "key": "localDateTime"
+  }
+]
+```
 
 ## Parent priority
 
-Keywords can be provided to prioritize the file that is selected as the parent. For example:
+By default, jpg, jpeg, and png files are prioritized to be the parent.
+
+Keywords can be provided to provide additional weight to files when sorting. For example:
 
 ```shell
 docker -e PARENT_PROMOTE="edit,crop,hdr" ...
-``` 
+```
+
+This will sort like this:
+
+```txt
+IMG_1234_hdr_crop.jpg   # score -102
+IMG_1234_crop.jpg       # score -101
+IMG_1234.jpg            # score -100
+IMG_1234_edit_crop.raw  # score -2
+IMG_1234.raw            # score 0
+```
 
 ## License
 

--- a/immich_auto_stack.py
+++ b/immich_auto_stack.py
@@ -205,11 +205,6 @@ def stackBy(data: list, criteria) -> list:
   return groups
 
 def stratifyStack(stack: list) -> list:
-  parent_ext = ['.jpg', '.jpeg', '.png']
-  parent_ext2 = ['.3fr', '.ari', '.arw', '.bay', '.braw', '.crw', '.cr2', '.cr3', '.cap', '.data', '.dcs', '.dcr', '.dng', '.drf', '.eip', '.erf', '.fff', '.gpr', '.iiq', '.k25', '.kdc', '.mdc', '.mef', '.mos', '.mrw', '.nef', '.nrw', '.obm', '.orf', '.pef', '.ptx', '.pxn', '.r3d', '.raf', '.raw', '.rwl', '.rw2', '.rwz', '.sr2', '.srf', '.srw', '.tif', '.x3f']
-  parents = []
-  children = []
-
   # Ensure the desired parent is first in the list
   return sorted(stack, key=parent_criteria)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 requests
+str2bool==1.1

--- a/tests/test_criteria.py
+++ b/tests/test_criteria.py
@@ -1,0 +1,250 @@
+from datetime import timedelta
+from faker import Faker
+from itertools import groupby
+import os
+import pytest
+from unittest.mock import patch
+
+from immich_auto_stack import apply_criteria
+
+fake = Faker()
+static_datetime = fake.date_time()
+
+
+def asset_factory(filename="IMG_1234.jpg", date_time=static_datetime):
+    return {
+        "originalFileName": filename,
+        "localDateTime": date_time,
+    }
+
+
+@pytest.mark.parametrize(
+    "file_list",
+    [
+        [
+            "IMG_2482.jpg",
+            "IMG_2482.jpg",  # same file, different folder
+        ],
+        [
+            "IMG_2482.jpg",
+            "IMG_2482.cr2",
+        ],
+        [
+            "DSCF2482.JPG",
+            "DSCF2482.RAF",
+        ],
+        [
+            "IMG_7584.MOV",
+            "IMG_7584.HEIC",
+        ],
+        [
+            "foo_bar_biz_baz_buz.jpg",
+            "foo_bar_biz_baz_buz.png",
+        ],
+    ],
+)
+def test_groupby_default_criteria_given_simple_matching_filenames_return_one_group(
+    file_list,
+):
+    # Arrange
+    asset_list = [asset_factory(f) for f in file_list]
+
+    # Act
+    result = [list(g) for k, g in groupby(asset_list, apply_criteria)]
+
+    # Assert
+    assert len(result) == 1
+    assert len(result[0]) == len(file_list)
+
+
+@pytest.mark.parametrize(
+    "file_list",
+    [
+        [
+            "IMG_2482.jpg",
+            "IMG_2483.cr2",
+        ],
+        [
+            "IMG_2482.JPG",
+            "IMG_2482_edit.JPG",
+        ],
+        [
+            "foo_bar_biz_baz_buz.jpg",
+            "bar_biz_baz_buz.png",
+            "foo_bar_biz_baz.raw",
+        ],
+    ],
+)
+def test_groupby_default_criteria_given_simple_list_of_non_matching_filenames_return_multiple_groups(
+    file_list,
+):
+    # Arrange
+    asset_list = [asset_factory(f) for f in file_list]
+
+    # Act
+    result = [list(g) for k, g in groupby(asset_list, apply_criteria)]
+
+    # Assert
+    assert len(result) == len(file_list)
+
+
+@pytest.mark.parametrize(
+    "file_list",
+    [
+        [
+            "IMG_2482_crop_edit.jpg",
+            "IMG_2482.jpg",
+            "IMG_2482.cr2",
+        ],
+        [
+            "IMG-2482_crop_edit.jpg",
+            "IMG-2482.jpg",
+            "IMG-2482.cr2",
+        ],
+        [
+            "IMG_7584_edited.MOV",
+            "IMG_7584_edited.HEIC",
+            "IMG_7584.MOV",
+            "IMG_7584.HEIC",
+        ],
+        [
+            "IMG_3745-3747_stitch_vintage-3.jpg",
+            "IMG_3745-3747_stitch_vintage.jpg",
+            "IMG_3745-3747_stitch.psd",
+            "IMG_3745-3747_stitch-4.jpg",
+        ],
+        ["IMG_3641_crop_vintage1234.jpg", "IMG_3641.JPG", "IMG_3641.CR2"],
+        [
+            "IMG_3594_crop2_vintage.jpg",
+            "IMG_3594_crop_vintage.jpg",
+            "IMG_3594_crop_vintage.psd",
+            "IMG_3594.psd",
+            "IMG_3594.JPG",
+            "IMG_3594.CR2",
+        ],
+        [
+            "IMG_1606-1608_mod2.jpg",
+            "IMG_1606-1608_mod2_2.jpg",
+            "IMG_1606-1608-hdr3-edit-edit.jpg",
+            "IMG_1606-1608-hdr3-edit.tif",
+        ],
+        [
+            "IMG_1606-Edit-edit.jpg",
+            "IMG_1606-Edit.tif",
+            "IMG_1606-HDR-Edit-edit.jpg",
+            "IMG_1606-HDR.dng",
+            "IMG_1606.CR2",
+            "IMG_1606.JPG",
+        ],
+        [
+            "IMG_4169_edit.jpg",
+            "IMG_4169_edit-resized.jpg",
+            "IMG_4169-edit2.jpg",
+            "IMG_4169-edit2-resized.jpg",
+            "IMG_4169.CR2",
+            "IMG_4169.JPG",
+        ],
+        [
+            "IMG_4153_edit (Medium).jpg",
+            "IMG_4153.psd",
+            "IMG_4153.JPG",
+            "IMG_4153.CR2",
+        ],
+        [
+            "IMG_2539-2540_crop_edit.jpg",
+            "IMG_2539-2540_crop_edit.resized.jpg",
+            "IMG_2539-2540.psd",
+        ],
+        [
+            "DSCF3744-HDR-Pano-edit.jpg",
+            "DSCF3744-HDR-Pano.dng",
+            "DSCF3744-HDR.dng",
+            "DSCF3744.JPG",
+            "DSCF3744.RAF",
+        ],
+        [
+            "DSCF2700-edit-12mp.jpg",
+            "DSCF2700-edit.jpg",
+            "DSCF2700.JPG",
+            "DSCF2700.RAF",
+        ],
+        [
+            "DSCF5278-Edit-edit-12mp.jpg",
+            "DSCF5278-Edit.tif",
+            "DSCF5278.RAF",
+        ],
+    ],
+)
+def test_groupby_custom_criteria_given_matching_filenames_return_one_group(file_list):
+    # Arrange
+    asset_list = [asset_factory(f) for f in file_list]
+    # test_regex = r'([A-Z]+[-_]?[0-9]{4}([-_][0-9]{4})?)([\._-].*)?\.[\w]{3,4}$'
+    test_criteria_json = r'[{"key": "originalFileName", "regex": {"key": "([A-Z]+[-_]?[0-9]{4}([-_][0-9]{4})?)([\\._-].*)?\\.[\\w]{3,4}$"}},{"key": "localDateTime"}]'
+
+    # Act
+    with patch.dict(os.environ, {"CRITERIA": test_criteria_json}):
+        result = [list(g) for k, g in groupby(asset_list, apply_criteria)]
+
+    # Assert
+    assert len(result) == 1
+    assert len(result[0]) == len(file_list)
+
+
+@pytest.mark.parametrize(
+    "file_list",
+    [
+        [
+            "IMG_2482_crop_edit.jpg",
+            "IMG_2483_crop_edit.jpg",
+        ],
+        [
+            "IMG_2488.jpg",
+            "IMG-2488.jpg",
+            "DSCF2488.jpg",
+            "DSCF-2488.jpg",
+            "DSCF_2488.jpg",
+        ],
+        [
+            "IMG_2488-edit.jpg",
+            "IMG-2488-edit.jpg",
+            "DSCF2488-edit.jpg",
+            "DSCF-2488-edit.jpg",
+            "DSCF_2488-edit.jpg",
+        ],
+        [
+            "IMG_1606-1608_mod2.jpg",
+            "IMG_1606.jpg",
+            "IMG_1608.jpg",
+        ],
+    ],
+)
+def test_groupby_custom_criteria_given_non_matching_filenames_return_multiple_groups(
+    file_list,
+):
+    # Arrange
+    asset_list = [asset_factory(f) for f in file_list]
+    # test_regex = r'([A-Z]+[-_]?[0-9]{4}([-_][0-9]{4})?)([\._-].*)?\.[\w]{3,4}$'
+    test_criteria_json = r'[{"key": "originalFileName", "regex": {"key": "([A-Z]+[-_]?[0-9]{4}([-_][0-9]{4})?)([\\._-].*)?\\.[\\w]{3,4}$"}},{"key": "localDateTime"}]'
+
+    # Act
+    with patch.dict(os.environ, {"CRITERIA": test_criteria_json}):
+        result = [list(g) for k, g in groupby(asset_list, apply_criteria)]
+
+    # Assert
+    assert len(result) == len(file_list)
+
+
+def test_groupby_default_criteria_given_different_datetimes_return_multiple_groups():
+    # Arrange
+    test_datetime = fake.unique.date_time()
+    asset_list = [
+        asset_factory("IMG_1234.jpg", test_datetime),
+        asset_factory("IMG_1234.jpg", test_datetime + timedelta(milliseconds=1)),
+        asset_factory("IMG_1234.jpg", test_datetime - timedelta(milliseconds=1)),
+    ]
+
+    # Act
+    result = [list(g) for k, g in groupby(asset_list, apply_criteria)]
+
+    # Assert
+    assert len(result) == 3

--- a/tests/test_parent_criteria.py
+++ b/tests/test_parent_criteria.py
@@ -1,0 +1,227 @@
+from datetime import timedelta
+from faker import Faker
+from itertools import groupby
+import os
+import pytest
+from unittest.mock import patch
+
+from immich_auto_stack import parent_criteria
+
+fake = Faker()
+static_datetime = fake.date_time()
+
+
+def asset_factory(filename="IMG_1234.jpg"):
+    return {
+        "originalFileName": filename,
+    }
+
+
+@pytest.mark.parametrize(
+    "input_order,expected_order",
+    [
+        [
+            [
+                "IMG_2482.xyz",
+                "IMG_2482.XYZ",
+                "IMG_2482.xyzz",
+                "IMG_2482.xyz2",
+                "IMG_2482x.xyz",
+                "IMG_2482.zzz",
+                "IMG_2482.ZZZ",
+            ],
+            [
+                "IMG_2482.XYZ",
+                "IMG_2482.ZZZ",
+                "IMG_2482.xyz",
+                "IMG_2482.xyz2",
+                "IMG_2482.xyzz",
+                "IMG_2482.zzz",
+                "IMG_2482x.xyz",
+            ],
+        ],
+        [
+            [
+                "IMG_2482_f.jpg",
+                "IMG_2482_a.jpg",
+                "IMG_2482_c.jpg",
+                "IMG_2482_e.jpg",
+                "IMG_2482_b.jpg",
+                "IMG_2482_d.jpg",
+            ],
+            [
+                "IMG_2482_a.jpg",
+                "IMG_2482_b.jpg",
+                "IMG_2482_c.jpg",
+                "IMG_2482_d.jpg",
+                "IMG_2482_e.jpg",
+                "IMG_2482_f.jpg",
+            ],
+        ],
+    ],
+)
+def test_parent_criteria_given_no_promote_override_sorts_alphabetically(input_order, expected_order):
+    # Arrange
+    asset_list = [asset_factory(f) for f in input_order]
+    expected_order = [asset_factory(f) for f in expected_order]
+
+    # Act
+    result = sorted(asset_list, key=parent_criteria)
+
+    # Assert
+    assert result == expected_order
+
+
+@pytest.mark.parametrize(
+    "input_order,expected_order",
+    [
+        [
+            [
+                "IMG_2482.xyz",
+                "IMG_2482.jpg",
+                "IMG_2482.png",
+                "IMG_2482.abc",
+                "IMG_2482.jpeg",
+            ],
+            [
+                "IMG_2482.jpeg",
+                "IMG_2482.jpg",
+                "IMG_2482.png",
+                "IMG_2482.abc",
+                "IMG_2482.xyz",
+            ],
+        ],
+        [
+            [
+                "IMG_2482.abc",
+                "IMG_2482.ABC",
+                "IMG_2482.png",
+                "IMG_2482.PNG",
+                "IMG_2482.jpg",
+                "IMG_2482.jpeg",
+                "IMG_2482.JPG",
+                "IMG_2482.JPEG",
+            ],
+            [
+                "IMG_2482.JPEG",
+                "IMG_2482.JPG",
+                "IMG_2482.PNG",
+                "IMG_2482.jpeg",
+                "IMG_2482.jpg",
+                "IMG_2482.png",
+                "IMG_2482.ABC",
+                "IMG_2482.abc",
+            ],
+        ],
+        [
+            [
+                "IMG_2482.abc",
+                "IMG_2482x.jpg",
+                "IMG_2482a.png",
+                "IMG_2482b.xyz",
+            ],
+            [
+                "IMG_2482a.png",
+                "IMG_2482x.jpg",
+                "IMG_2482.abc",
+                "IMG_2482b.xyz",
+            ],
+        ],
+    ],
+)
+def test_parent_criteria_given_no_promote_override_prioritizes_jpg_jpeg_png(input_order, expected_order):
+    # Arrange
+    asset_list = [asset_factory(f) for f in input_order]
+    expected_order = [asset_factory(f) for f in expected_order]
+
+    # Act
+    result = sorted(asset_list, key=parent_criteria)
+
+    # Assert
+    assert result == expected_order
+
+
+@pytest.mark.parametrize(
+    "input_order,promote_str,expected_order",
+    [
+        [
+            [
+                "testIMG_2482.xyz",
+                "IMG_2482.jpg",
+                "IMG_2482.test.png",
+                "IMG_2482.abc",
+                "IMG_2482.jpeg",
+            ],
+            "test",
+            [
+                "IMG_2482.test.png",
+                "IMG_2482.jpeg",
+                "IMG_2482.jpg",
+                "testIMG_2482.xyz",
+                "IMG_2482.abc",
+            ],
+        ],
+        [
+            [
+                "IMG_2482.a",
+                "IMG_2482.tesb",
+                "IMG_2482tesT.c",
+                "IMG_2482.d",
+                "IMG_2482testtest.e",
+                "IMG_2482foo_test.f",
+                "IMG_2482.jpg",
+            ],
+            "test,foo",
+            [
+                "IMG_2482.jpg",
+                "IMG_2482foo_test.f",
+                "IMG_2482tesT.c",
+                "IMG_2482testtest.e",
+                "IMG_2482.a",
+                "IMG_2482.d",
+                "IMG_2482.tesb",
+            ],
+        ],
+        [
+            [
+                "IMG_2482_abc.abc",
+                "IMG_2482_foo.jpg",
+                "IMG_2482_test_foo.jpg",
+                "IMG_2482_test_foo.xyz",
+            ],
+            "test,foo",
+            [
+                "IMG_2482_test_foo.jpg",
+                "IMG_2482_foo.jpg",
+                "IMG_2482_test_foo.xyz",
+                "IMG_2482_abc.abc",
+            ],
+        ],
+        [
+            [
+                "IMG_2482_abc.abc",
+                "IMG_2482_foo.jpg",
+                "IMG_2482_test_foo.jpg",
+                "IMG_2482_test_foo.xyz",
+            ],
+            "",
+            [
+                "IMG_2482_foo.jpg",
+                "IMG_2482_test_foo.jpg",
+                "IMG_2482_abc.abc",
+                "IMG_2482_test_foo.xyz",
+            ],
+        ],
+    ],
+)
+def test_parent_criteria_given_promote_override_prioritizes_promote_matches(input_order, promote_str, expected_order):
+    # Arrange
+    asset_list = [asset_factory(f) for f in input_order]
+    expected_order = [asset_factory(f) for f in expected_order]
+
+    # Act
+    with patch.dict(os.environ, {"PARENT_PROMOTE": promote_str}):
+        result = sorted(asset_list, key=parent_criteria)
+
+    # Assert
+    assert result == expected_order


### PR DESCRIPTION
I'm making some changes in my own fork, posting a PR in case you find the functionality worth adopting.

## Customizing the criteria

Configurable criteria allows for the customization of how files are grouped
The default in pretty json is:

```json
[
  {
    "key": "originalFileName",
    "split": {
      "key": ".",
      "index": 0 // this is the default
    }
  },
  {
    "key": "localDateTime"
  }
]
```

Functionally, this JSON config is the same as the lamdba implementation currently in place:

```python
lambda x: (
  x["originalFileName"].split(".")[0],
  x["localDateTime"]
)
```

To override the default, pass a new configuration file into docker via
The CRITERIA env var.

```shell
docker -e CRITERIA='[{"key": "originalFileName", "split": {"key": "_", "index": 0}}]' ...
``` 

The parser also supports regex, which adds a lot more flexibility. The index will select a substring using `re.match.group(index)`. For example:

```json
[
  {
    "key": "originalFileName",
    "regex": {
      "key": "([A-Z]+[-_]?[0-9]{4}([-_][0-9]{4})?)([\\._-].*)?\\.[\\w]{3,4}$",
      "index": 1 // this is the default
    }
  },
  {
    "key": "localDateTime"
  }
]
```

## Parent priority

Keywords can be provided to prioritize the file that is selected as the parent, on top of the existing jpg/png prioritization currently in place. For example:

```shell
docker -e PARENT_PROMOTE="edit,crop,hdr" ...
``` 

This will sort like:

```txt
IMG_1234_hdr_crop.jpg
IMG_1234_crop.jpg
IMG_1234.jpg
IMG_1234_edit_crop.raw
IMG_1234.raw
```