### PR TITLE
Fix broken tests triggered by merging #2 and #3

### DIFF
--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -1,0 +1,27 @@
+name: Unit tests
+
+# Influenced by https://docs.github.com/en/actions/use-cases-and-examples/building-and-testing/building-and-testing-python
+
+on: [push]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements-test.txt
+      - name: Test with pytest
+        run: |
+          pytest --junitxml=junit/test-results.xml --cov --cov-report=xml

--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,7 @@ coverage.xml
 .hypothesis/
 .pytest_cache/
 cover/
+junit/
 
 # Translations
 *.mo

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,3 +2,9 @@
 pythonpath = [
   "."
 ]
+
+[tool.coverage.run]
+source = ["."]
+omit = [
+    "tests/*",
+]

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,11 +1,13 @@
 -r requirements.txt
 
+coverage==7.6.1
 exceptiongroup==1.2.2
 Faker==27.0.0
 iniconfig==2.0.0
 packaging==24.1
 pluggy==1.5.0
 pytest==8.3.2
+pytest-cov==5.0.0
 python-dateutil==2.9.0.post0
 six==1.16.0
 tomli==2.0.1

--- a/tests/test_stratifyStack.py
+++ b/tests/test_stratifyStack.py
@@ -57,9 +57,9 @@ def test_stratifyStack_puts_single_parent_at_front(extensions, expected_first_ex
 @pytest.mark.parametrize(
     "extensions,expected_parents",
     [
-        (["jpg", "jpeg"], ["jpg", "jpeg"]),
-        (["png", "raw", "cr2", "xmp", "jpg"], ["png", "jpg"]),
-        (["png", "jpg", "png", "png"], ["png", "jpg", "png", "png"]),
+        (["jpg", "jpeg"], ["jpeg", "jpg"]),
+        (["png", "raw", "cr2", "xmp", "jpg"], ["jpg", "png"]),
+        (["png", "jpg", "png", "png"], ["jpg", "png", "png", "png"]),
     ],
 )
 def test_stratifyStack_handles_multiple_parents(extensions, expected_parents):


### PR DESCRIPTION
This is a good example of the value of unit tests.

The tests that are failing were added by #3.

When we later merged #2, it changed how the parent images are ordered very slightly, breaking tests from #3. The new implementation sorts alphabetically.

In the diff, note that the changes are just alphabetization adjustments.
- `jpeg` before `jpg`
- `jpg` before `png`

The tests for stratifyStack were actually added in #3, which was merged later. If we had unit tests integrated into Github Actions, the tests would've been failing after you merged #2.

I'm pushing a github actions config for this automation!