### PR TITLE
Add some thoughtful handling around "None" cases

### DIFF
--- a/immich_auto_stack.py
+++ b/immich_auto_stack.py
@@ -42,7 +42,9 @@ def get_criteria_config():
 def apply_criteria(x):
     criteria_list = []
     for item in get_criteria_config():
-        value = x[item["key"]]
+        value = x.get(item["key"])
+        if value is None:
+            return []
         if "split" in item.keys():
             split_key = item["split"]["key"]
             split_index = item["split"]["index"]

--- a/immich_auto_stack.py
+++ b/immich_auto_stack.py
@@ -39,11 +39,26 @@ def get_criteria_config():
         return json.loads(criteria_override)
     return criteria_default
 
-def apply_criteria(x):
+def apply_criteria(x: dict) -> list:
+    """
+    Given a photo dataset, pick out the identified keys as defined by CRITERIA.
+
+    Keys can be raw values or a subset of values (using split or regex modifiers).
+
+    If any of the key values is abnormal (None, absent, regex mismatch), return
+    an empty list.
+    """
     criteria_list = []
     for item in get_criteria_config():
         value = x.get(item["key"])
         if value is None:
+            # None is a undesireable key value for this project because we rely on keys
+            # to categorize similar photos, and typically None represents the absence
+            # of information.
+            #
+            # A real scenario example: suppose some photos have not yet generated
+            # thumbnails. It would be undesireable to create a stack of all the photos
+            # whose thumbhash is None.
             return []
         if "split" in item.keys():
             split_key = item["split"]["key"]
@@ -157,6 +172,14 @@ def stackBy(data: list, criteria) -> list:
   
   # Filter only groups that have more than one item
   groups = [x for x in groups if len(x[1]) > 1 ] 
+
+  # Raise error if any groups have an empty key
+  if any((group[0] == [] or None in group[0]) for group in groups):
+      raise Exception(
+          "Some photos do not match the criteria you provided. Consider refining your"
+          "criteria. If the criteria was not intended to match all files, use the"
+          "SKIP_MATCH_MISS environment variable to skip processing of those photos."
+      )
 
   return groups
 


### PR DESCRIPTION
This PR is triggered by a scenario I had where some of my photos had `thumbhash: None`. This was throwing the following exception:

```
TypeError: '<' not supported between instances of 'NoneType' and 'str'
```

This made me wonder... do we want to stack files where a key is None? Probably not!

I'm not sure if it's possible for localDateTime or originalFilename values to be None or absent, but the concern would apply there as well. Imagine stacking all photos that don't have a localDateTime - it's not logical.

The adjustments I recommend in this PR are:

- Be more explicit (in code, comments, tests) that an empty list `[]` is how we represent a scenario where we had trouble creating the criteria keys. This could be because of a regex mismatch, null value, or something we haven't thought of yet.
  - `[]` is better than putting `None` list because None causes with python's sort function.
- Raise an exception if the empty key (`[]`) appears in the list of stacks. Also to be safe, raise an exception if any None values appear in the stack keys.
- Repurpose SKIP_MATCH_MISS to filter any "empty key" (`[]`) results, not just regex mismatch.


A realistic scenario:

Suppose:
- Our criteria is [{"key": "thumbhash"},{"key":"localDateTime"}]
- We have 5000 photos in the system.
- All files have localDateTime
- 100 files have thumbhash=None

The changes in the PR will:
1. Raise an exception on a default run because 100 files do not match the criteria
2. With SKIP_MATCH_MISS=true, 4900 files will be processed and 100 will be skipped

The important takeaway from my perspective is there are no scenarios were all 5000 files are processed given the provided criteria.