### PR TITLE
Improve API response handling and logging

### DIFF
--- a/immich_auto_stack.py
+++ b/immich_auto_stack.py
@@ -125,14 +125,18 @@ class Immich():
     session.mount('https://', adapter)
 
     while payload["page"] != None:
-      response = session.post(f"{self.api_url}/search/metadata", headers=self.headers, json=payload)
+    response = session.post(f"{self.api_url}/search/metadata", headers=self.headers, json=payload)
 
-      if not response.ok:
-        logger.error('   Error:', response.status_code, response.text)
+    if not response.ok:
+        logger.error("   Error: %s %s", response.status_code, response.text)
 
-      response_data = response.json()
-      assets_total = assets_total + response_data['assets']['items']
-      payload["page"] = response_data['assets']['nextPage']
+    response_data = response.json()
+
+    assets_total = assets_total + response_data['assets']['items']
+
+    next_page = response_data['assets']['nextPage']
+    payload["page"] = int(next_page) if next_page is not None else None
+
     
     self.assets = assets_total
     

--- a/immich_auto_stack.py
+++ b/immich_auto_stack.py
@@ -14,30 +14,27 @@ from urllib3.util.retry import Retry
 from urllib.parse import urlparse
 
 logging.basicConfig(
-  stream=sys.stdout, 
-  level=logging.INFO, 
-  format='%(asctime)s - %(levelname)s - %(message)s'
+    stream=sys.stdout,
+    level=logging.INFO,
+    format="%(asctime)s - %(levelname)s - %(message)s",
 )
 logger = logging.getLogger(__name__)
 
 criteria_default = [
-  {
-    "key": "originalFileName",
-    "split": {
-      "key": ".",
-      "index": 0
-    }
-  },
-  {
-    "key": "localDateTime"
-  }
+    {
+        "key": "originalFileName",
+        "split": {"key": ".", "index": 0},
+    },
+    {"key": "localDateTime"},
 ]
+
 
 def get_criteria_config():
     criteria_override = os.environ.get("CRITERIA")
     if criteria_override:
         return json.loads(criteria_override)
     return criteria_default
+
 
 def apply_criteria(x: dict) -> list:
     """
@@ -52,204 +49,203 @@ def apply_criteria(x: dict) -> list:
     for item in get_criteria_config():
         value = x.get(item["key"])
         if value is None:
-            # None is a undesireable key value for this project because we rely on keys
+            # None is an undesirable key value for this project because we rely on keys
             # to categorize similar photos, and typically None represents the absence
             # of information.
             #
             # A real scenario example: suppose some photos have not yet generated
-            # thumbnails. It would be undesireable to create a stack of all the photos
+            # thumbnails. It would be undesirable to create a stack of all the photos
             # whose thumbhash is None.
             return []
-        if "split" in item.keys():
+
+        if "split" in item:
             split_key = item["split"]["key"]
             split_index = item["split"]["index"]
             value = value.split(split_key)[split_index]
-        if "regex" in item.keys():
+
+        if "regex" in item:
             regex_key = item["regex"]["key"]
             # expects at least one regex group to be defined
             regex_index = item["regex"].get("index", 1)
             match = re.match(regex_key, value)
             if match:
-              value = match.group(regex_index)
+                value = match.group(regex_index)
             elif not str2bool(os.environ.get("SKIP_MATCH_MISS")):
-              raise Exception(f"Match not found for value: {value}, regex: {regex_key}")
+                raise Exception(f"Match not found for value: {value}, regex: {regex_key}")
             else:
-              return []
+                return []
+
         criteria_list.append(value)
+
     return criteria_list
 
+
 def parent_criteria(x):
-  parent_ext = ['.jpg', '.jpeg', '.png']
+    parent_ext = [".jpg", ".jpeg", ".png"]
 
-  parent_promote = list(filter(None, os.environ.get("PARENT_PROMOTE", "").split(",")))
-  parent_promote_baseline = 0
+    parent_promote = list(filter(None, os.environ.get("PARENT_PROMOTE", "").split(",")))
+    parent_promote_baseline = 0
 
-  lower_filename = x["originalFileName"].lower()
+    lower_filename = x["originalFileName"].lower()
 
-  if any(lower_filename.endswith(ext) for ext in parent_ext):
-    parent_promote_baseline -= 100
+    if any(lower_filename.endswith(ext) for ext in parent_ext):
+        parent_promote_baseline -= 100
 
-  for key in parent_promote:
-    if key.lower() in lower_filename:
-      logger.info("promoting " + x["originalFileName"] + f" for key {key}")
-      parent_promote_baseline -= 1
+    for key in parent_promote:
+        if key.lower() in lower_filename:
+            logger.info("promoting " + x["originalFileName"] + f" for key {key}")
+            parent_promote_baseline -= 1
 
-  return [parent_promote_baseline, x["originalFileName"]]
+    return [parent_promote_baseline, x["originalFileName"]]
 
 
-class Immich():
-  def __init__(self, url: str, key: str):
-    self.api_url = f'{urlparse(url).scheme}://{urlparse(url).netloc}/api'
-    self.headers = {
-      'x-api-key': key,
-      'Accept': 'application/json'
-    }
-    self.assets = list()
-  
-  def fetchAssets(self, size: int = 1000) -> list:
-    payload = {
-      'size' : size,
-      'page' : 1,
-      #'withExif': True,
-      'withStacked': True
-    }
-    assets_total = list()
+class Immich:
+    def __init__(self, url: str, key: str):
+        self.api_url = f"{urlparse(url).scheme}://{urlparse(url).netloc}/api"
+        self.headers = {"x-api-key": key, "Accept": "application/json"}
+        self.assets = list()
 
-    logger.info(f'⬇️  Fetching assets: ')
-    logger.info(f'   Page size: {size}')
+    def fetchAssets(self, size: int = 1000) -> list:
+        payload = {
+            "size": size,
+            "page": 1,
+            # 'withExif': True,
+            "withStacked": True,
+        }
+        assets_total = list()
 
-    session = Session()
-    retry = Retry(connect=3, backoff_factor=0.5)
-    adapter = HTTPAdapter(max_retries=retry)
-    session.mount('http://', adapter)
-    session.mount('https://', adapter)
+        logger.info("⬇️  Fetching assets: ")
+        logger.info(f"   Page size: {size}")
 
-    while payload["page"] != None:
-    response = session.post(f"{self.api_url}/search/metadata", headers=self.headers, json=payload)
+        session = Session()
+        retry = Retry(connect=3, backoff_factor=0.5)
+        adapter = HTTPAdapter(max_retries=retry)
+        session.mount("http://", adapter)
+        session.mount("https://", adapter)
 
-    if not response.ok:
-        logger.error("   Error: %s %s", response.status_code, response.text)
+        while payload["page"] is not None:
+            response = session.post(
+                f"{self.api_url}/search/metadata",
+                headers=self.headers,
+                json=payload,
+            )
 
-    response_data = response.json()
+            if not response.ok:
+                logger.error("   Error: %s %s", response.status_code, response.text)
 
-    assets_total = assets_total + response_data['assets']['items']
+            response_data = response.json()
 
-    next_page = response_data['assets']['nextPage']
-    payload["page"] = int(next_page) if next_page is not None else None
+            assets_total = assets_total + response_data["assets"]["items"]
 
-    
-    self.assets = assets_total
-    
-    logger.info(f'   Pages: {payload["page"]}')   
-    logger.info(f'   Assets: {len(self.assets)}')
-    
-    return self.assets
+            next_page = response_data["assets"]["nextPage"]
+            payload["page"] = int(next_page) if next_page is not None else None
 
-  def modifyAssets(self, payload: dict) -> None:
-    session = Session()
-    retry = Retry(connect=3, backoff_factor=0.5)
-    adapter = HTTPAdapter(max_retries=retry)
-    session.mount('http://', adapter)
-    session.mount('https://', adapter)
+        self.assets = assets_total
 
-    response = session.put(f"{self.api_url}/assets", headers=self.headers, json=payload)
+        logger.info(f"   Pages: {payload['page']}")
+        logger.info(f"   Assets: {len(self.assets)}")
 
-    if response.ok:
-      logger.info("  🟢 Success!")
-    else:
-      logger.error(f"  🔴 Error! {response.status_code} {response.text}") 
+        return self.assets
+
+    def modifyAssets(self, payload: dict) -> None:
+        session = Session()
+        retry = Retry(connect=3, backoff_factor=0.5)
+        adapter = HTTPAdapter(max_retries=retry)
+        session.mount("http://", adapter)
+        session.mount("https://", adapter)
+
+        response = session.put(f"{self.api_url}/assets", headers=self.headers, json=payload)
+
+        if response.ok:
+            logger.info("  🟢 Success!")
+        else:
+            logger.error(f"  🔴 Error! {response.status_code} {response.text}")
 
 
 def stackBy(data: list, criteria) -> list:
-  # Optional: remove incompatible file names
-  if str2bool(os.environ.get("SKIP_MATCH_MISS")):
-    data = filter(criteria, data)
+    # Optional: remove incompatible file names
+    if str2bool(os.environ.get("SKIP_MATCH_MISS")):
+        data = filter(criteria, data)
 
-  # Sort by primary and secondary criteria
-  data = sorted(data, key=criteria)
+    # Sort by primary and secondary criteria
+    data = sorted(data, key=criteria)
 
-  # Group by primary and secondary criteria
-  groups = groupby(data, key=criteria)
-  
-  # Extract and process groups into a list of tuples
-  groups = [(key, list(group)) for key, group in groups]
-  
-  # Filter only groups that have more than one item
-  groups = [x for x in groups if len(x[1]) > 1 ] 
+    # Group by primary and secondary criteria
+    groups = groupby(data, key=criteria)
 
-  # Raise error if any groups have an empty key
-  if any((group[0] == [] or None in group[0]) for group in groups):
-      raise Exception(
-          "Some photos do not match the criteria you provided. Consider refining your"
-          "criteria. If the criteria was not intended to match all files, use the"
-          "SKIP_MATCH_MISS environment variable to skip processing of those photos."
-      )
+    # Extract and process groups into a list of tuples
+    groups = [(key, list(group)) for key, group in groups]
 
-  return groups
+    # Filter only groups that have more than one item
+    groups = [x for x in groups if len(x[1]) > 1]
+
+    # Raise error if any groups have an empty key
+    if any((group[0] == [] or None in group[0]) for group in groups):
+        raise Exception(
+            "Some photos do not match the criteria you provided. Consider refining your"
+            "criteria. If the criteria was not intended to match all files, use the"
+            "SKIP_MATCH_MISS environment variable to skip processing of those photos."
+        )
+
+    return groups
+
 
 def stratifyStack(stack: list) -> list:
-  # Ensure the desired parent is first in the list
-  return sorted(stack, key=parent_criteria)
+    # Ensure the desired parent is first in the list
+    return sorted(stack, key=parent_criteria)
 
 
 def main():
+    api_key = os.environ.get("API_KEY", False)
+    api_url = os.environ.get("API_URL", "http://immich_server:3001/api")
+    skip_previous = str2bool(os.environ.get("SKIP_PREVIOUS", True))
+    dry_run = str2bool(os.environ.get("DRY_RUN", False))
 
-  api_key = os.environ.get("API_KEY", False)
+    if not api_key:
+        logger.warning("API key is required")
+        return
 
-  api_url = os.environ.get("API_URL", "http://immich_server:3001/api")
+    logger.info("============== INITIALIZING ==============")
 
-  skip_previous = str2bool(os.environ.get("SKIP_PREVIOUS", True))
+    if dry_run:
+        logger.info("🔒  Dry run enabled, no changes will be applied")
 
-  dry_run = str2bool(os.environ.get("DRY_RUN", False))
+    immich = Immich(api_url, api_key)
 
-  if not api_key:
-    logger.warn("API key is required")
-    return
+    assets = immich.fetchAssets()
 
-  logger.info('============== INITIALIZING ==============')
+    stacks = stackBy(assets, apply_criteria)
 
-  if dry_run:
-    logger.info('🔒  Dry run enabled, no changes will be applied')
-  
-  immich = Immich(api_url, api_key)
-  
-  assets = immich.fetchAssets()
+    for i, v in enumerate(stacks):
+        key, stack = v
 
-  stacks = stackBy(assets, apply_criteria)
+        stack = stratifyStack(stack)
 
-  for i, v in enumerate(stacks):
-    key, stack = v
+        parent_id = stack[0]["id"]
+        children_id = []
 
-    stack = stratifyStack(stack)
+        if skip_previous:
+            children_id = [x["id"] for x in stack[1:] if x["stackCount"] is None]
 
-    parent_id = stack[0]['id']
-    children_id = []
-    
-    if skip_previous:
-      children_id = [x['id'] for x in stack[1:] if x['stackCount'] == None ]
-      
-      if len(children_id) == 0:
-        logger.info(f'{i}/{len(stacks)} Key: {key} SKIP! No new children!')
-        continue
-      
-    else:
-      children_id = [x['id'] for x in stack[1:]]
+            if len(children_id) == 0:
+                logger.info(f"{i}/{len(stacks)} Key: {key} SKIP! No new children!")
+                continue
+        else:
+            children_id = [x["id"] for x in stack[1:]]
 
-    logger.info(f'{i}/{len(stacks)} Key: {key}')
-    logger.info(f'   Parent name: {stack[0]["originalFileName"]} ID: {parent_id}')
-    
-    for child in stack[1:]:
-      logger.info(f'   Child name:  {child["originalFileName"]} ID: {child["id"]}')
+        logger.info(f"{i}/{len(stacks)} Key: {key}")
+        logger.info(f'   Parent name: {stack[0]["originalFileName"]} ID: {parent_id}')
 
-    if len(children_id) > 0:
-      payload = {
-        "ids": children_id,
-        "stackParentId": parent_id
-      }
+        for child in stack[1:]:
+            logger.info(f'   Child name:  {child["originalFileName"]} ID: {child["id"]}')
 
-      if not dry_run:
-        time.sleep(.1)
-        immich.modifyAssets(payload)
+        if len(children_id) > 0:
+            payload = {"ids": children_id, "stackParentId": parent_id}
 
-if __name__ == '__main__':
-  main()
+            if not dry_run:
+                time.sleep(0.1)
+                immich.modifyAssets(payload)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Immich’s /search/metadata endpoint now enforces numeric types for the page field. The original script forwarded nextPage directly, which may be returned as a string, causing Immich to reject the request with a 400 validation error. This resulted in missing assets fields and a subsequent KeyError.

Additionally, the logger used an invalid call signature, causing a TypeError during error reporting and masking the underlying API failure.

**This patch**:

Forces nextPage to be cast to int when present

Fixes the logger formatting to avoid runtime crashes

Restores compatibility with Immich 1.100+ pagination behavior

**With these changes**:

Asset pagination works correctly across all Immich versions tested

API errors are logged cleanly and consistently

The script no longer crashes due to type mismatches or logging failures

immich-auto-stack regains full compatibility with Immich 1.100+